### PR TITLE
Add Codex CLI support as alternative agent backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ Autonomous AI agent loop for iterative feature implementation.
 
 ## About
 
-Ralph orchestrates Claude Code in a loop to implement features story-by-story from a PRD (Product Requirements Document). Each iteration picks one user story, implements it, runs quality checks, commits, and stops. The loop continues until all stories pass.
+Ralph orchestrates a coding agent (Claude Code or Codex CLI) in a loop to implement features story-by-story from a PRD (Product Requirements Document). Each iteration picks one user story, implements it, runs quality checks, commits, and stops. The loop continues until all stories pass.
 
 ## Structure
 
 ```
 ralph/
-├── ralph.sh              # Main loop script (~330 lines bash)
+├── ralph.sh              # Main loop script (~730 lines bash)
 ├── cleanup.sh            # Archive completed runs
 ├── prompts/
 │   ├── agent.md          # Default agent prompt (project-agnostic)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,8 @@ ralph/
 
 | Mechanism | How It Works |
 |-----------|-------------|
-| **Iteration loop** | `ralph.sh` runs `claude -p <prompt> --output-format json` up to N times |
+| **Iteration loop** | `ralph.sh` runs the selected agent (claude or codex) up to N times |
+| **Agent selection** | `--agent auto\|claude\|codex` chooses backend; auto prefers claude |
 | **Per-PRD workspaces** | `--prd <name>` creates isolated folder at `workspaces/<name>/` |
 | **Context injection** | `--context` flag lists file paths in the prompt via `{{CONTEXT_SECTION}}` |
 | **Prompt placeholders** | `{{WORKSPACE}}` and `{{CONTEXT_SECTION}}` are substituted at runtime |
@@ -41,7 +42,10 @@ ralph/
 
 ```bash
 # Run ralph (from the project root, not ralph/)
-./ralph/ralph.sh --prd my-feature 15                                # 15 iterations
+./ralph/ralph.sh --prd my-feature 15                                # 15 iterations (auto-detect agent)
+./ralph/ralph.sh --prd my-feature 15 --agent claude                 # Force Claude Code
+./ralph/ralph.sh --prd my-feature 15 --agent codex                  # Force Codex CLI
+./ralph/ralph.sh --prd my-feature 15 --agent auto                   # Auto-detect (default)
 ./ralph/ralph.sh --prd my-feature 15 --context docs/architecture.md # With context
 ./ralph/ralph.sh --prd my-feature 15 --context docs/ --context CLAUDE.md
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Ralph prints a diagnostics table after each iteration:
 
 ```
 ┌──────────────────────────────────────────────────┐
-│  ITERATION 3  DIAGNOSTICS                        │
+│  ITERATION 3  DIAGNOSTICS (claude)               │
 ├──────────────────────────────────────────────────┤
 │  ⏱  Time:   3m 42s     API: 3m 12s              │
 │  🔄 Turns:  47                                   │

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 Autonomous AI agent loop that implements features story-by-story from a PRD.
 
-Ralph runs [Claude Code](https://docs.anthropic.com/en/docs/claude-code) in a loop. Each iteration picks one user story from a PRD, implements it completely (code + tests + commit), and stops. The loop continues until every story passes or the iteration limit is reached.
+Ralph runs a coding agent ([Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Codex CLI](https://github.com/openai/codex)) in a loop. Each iteration picks one user story from a PRD, implements it completely (code + tests + commit), and stops. The loop continues until every story passes or the iteration limit is reached.
 
 ## How It Works
 
 ```
-┌─────────────┐     ┌──────────────┐     ┌──────────────┐
-│  prd.json   │────>│  ralph.sh    │────>│  Claude Code │
-│  (stories)  │     │  (loop)      │     │  (1 story)   │
-└─────────────┘     └──────┬───────┘     └──────┬───────┘
+┌─────────────┐     ┌──────────────┐     ┌──────────────────┐
+│  prd.json   │────>│  ralph.sh    │────>│  Claude / Codex  │
+│  (stories)  │     │  (loop)      │     │  (1 story)       │
+└─────────────┘     └──────┬───────┘     └──────┬───────────┘
                            │                     │
                     ┌──────▼───────┐     ┌──────▼───────┐
                     │  metrics/    │     │  commit +    │
@@ -31,7 +31,9 @@ Ralph repeats this until all stories pass (`<promise>COMPLETE</promise>`) or max
 
 ## Prerequisites
 
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (`claude` command available)
+- At least one agent CLI:
+  - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (`claude` command)
+  - [Codex CLI](https://github.com/openai/codex) (`codex` command) — requires `codex exec`, `--json`, `--output-last-message`, `--sandbox workspace-write`
 - `jq` (JSON processor)
 - `bc` (calculator, usually pre-installed)
 
@@ -77,17 +79,34 @@ Both steps create a workspace folder at `ralph/workspaces/[feature-name]/` conta
 
 ```bash
 # From your project root
-./ralph/ralph.sh --prd <name> [max_iterations] [prompt_file] [--context <path>...]
+./ralph/ralph.sh --prd <name> [--agent auto|claude|codex] [max_iterations] [prompt_file] [--context <path>...]
 
 # Examples
-./ralph/ralph.sh --prd my-feature                                       # 10 iterations, default prompt
+./ralph/ralph.sh --prd my-feature                                       # 10 iterations, auto-detect agent
 ./ralph/ralph.sh --prd my-feature 15                                    # 15 iterations
+./ralph/ralph.sh --prd my-feature 15 --agent codex                      # Use Codex CLI
+./ralph/ralph.sh --prd my-feature 15 --agent claude                     # Use Claude Code
 ./ralph/ralph.sh --prd my-feature 15 --context docs/architecture.md     # With context file
 ./ralph/ralph.sh --prd my-feature 15 --context docs/ --context CLAUDE.md  # Multiple context sources
+./ralph/ralph.sh --prd my-feature 15 --no-multi-agent                   # Disable Codex sub-agent spawning
 ```
 
 - `--prd` is required — identifies the workspace at `ralph/workspaces/<name>/`
+- `--agent` selects the backend: `auto` (default, prefers Claude), `claude`, or `codex`
 - `--context` is repeatable — files are listed in the prompt for the agent to read at the start of each iteration. Directories are recursively expanded.
+- `--no-multi-agent` disables Codex's `--enable multi_agent` flag (on by default)
+
+### Agent Differences
+
+| Aspect | Claude Code | Codex CLI |
+|--------|------------|-----------|
+| Cost tracking | Per-iteration USD cost | Not available (shows "n/a") |
+| API duration | Available | Not available (shows "n/a") |
+| Context window % | Displayed | Not available (shows "n/a") |
+| Prompt delivery | `-p` flag | Piped via stdin |
+| Output format | Single JSON object | JSONL event stream |
+
+`CLAUDE.md` is a project convention file read by both agents — it is not specific to Claude Code.
 
 ### 4. Monitor Progress
 
@@ -183,12 +202,13 @@ ralph/
 
 ## Key Design Decisions
 
+- **Agent-agnostic**: Works with Claude Code or Codex CLI. Auto-detection prefers Claude when both are available.
 - **One story per iteration**: Prevents context overflow. Each iteration starts fresh with no memory of previous work.
 - **Per-PRD workspaces**: Each feature gets its own folder at `ralph/workspaces/<name>/`. All state (prd.json, progress.txt, metrics) is isolated. Archive moves the whole folder.
 - **Progress persistence**: `progress.txt` carries learnings between iterations within a workspace.
 - **Quality gates from CLAUDE.md**: The agent prompt is project-agnostic. Project-specific quality checks live in the host project's `CLAUDE.md`.
 - **Context via `--context` flag**: Pass architecture docs, feature plans, or entire directories as context. Paths are listed in the prompt; the agent reads them at runtime. Like pral's `--context` flag.
-- **Metrics tracking**: Every iteration records duration, token usage, and cost as JSON for analysis.
+- **Metrics tracking**: Every iteration records duration, token usage, and cost as JSON for analysis. Metrics unavailable from a given agent (e.g., Codex cost) are stored as `null` and displayed as "n/a".
 
 ## Companion Tool: PRAL
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Ralph reads quality check commands from your project's `CLAUDE.md`. Add a sectio
 - E2E: `./run_tests.sh [spec-file]`
 ```
 
-The agent prompt (`prompts/agent.md`) tells Claude to follow whatever quality checks your `CLAUDE.md` defines. No need to modify ralph's files.
+The agent prompt (`prompts/agent.md`) tells the agent to follow whatever quality checks your `CLAUDE.md` defines. No need to modify ralph's files.
 
 ### Custom Prompt
 

--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -7,7 +7,7 @@ You are an autonomous coding agent working on a software project.
 1. Read context files listed below (if any) for project architecture and feature plans
 2. Read the PRD at `{{WORKSPACE}}/prd.json`
 3. Read the progress log at `{{WORKSPACE}}/progress.txt` (check Codebase Patterns section first)
-4. Read `CLAUDE.md` at the project root (project-wide patterns, commands, and quality checks)
+4. Read `CLAUDE.md` at the project root (project-wide patterns, commands, and quality checks — this is a project convention file, not agent-specific)
 5. Check you're on the correct branch from PRD `branchName`. If not, check it out from the current branch.
 6. Pick the **highest priority** user story where `passes: false`
 7. Implement that single user story
@@ -25,7 +25,7 @@ You are an autonomous coding agent working on a software project.
 APPEND to {{WORKSPACE}}/progress.txt (never replace, always append):
 ```
 ## [Date/Time] - [Story ID]
-Session: <session-id>
+Session: <session-id or n/a>
 - What was implemented
 - Files changed
 - **Learnings for future iterations:**
@@ -35,18 +35,18 @@ Session: <session-id>
 ---
 ```
 
-**Getting Session ID**: Run this command to get your current session ID:
+**Getting Session ID (Claude Code only)**: If running under Claude Code, capture your session ID for potential resume:
 ```bash
-# macOS
+# macOS — skip this if not running under Claude Code
 project_encoded=$(pwd | tr '/' '-' | sed 's/^-//')
 session_file=$(stat -f '%m %N' ~/.claude/projects/-${project_encoded}/*.jsonl 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
-basename "$session_file" .jsonl
+basename "$session_file" .jsonl 2>/dev/null || echo "no-session"
 
 # Linux (use stat -c instead of stat -f)
 # session_file=$(stat -c '%Y %n' ~/.claude/projects/-${project_encoded}/*.jsonl 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
 ```
 
-Include the session ID so future iterations can resume context if needed using `claude --resume <session-id>`.
+If a session ID is available, include it in the progress entry. Otherwise, write `Session: n/a`.
 
 The progress.txt file serves as persistent context between sessions. Always read it first to understand what previous iterations accomplished and learned.
 

--- a/ralph.sh
+++ b/ralph.sh
@@ -43,6 +43,7 @@ usage() {
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --prd)
+      [[ -n "${2:-}" ]] || { echo "Error: --prd requires a value"; usage; }
       PRD_NAME="$2"
       shift 2
       ;;
@@ -51,6 +52,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --agent)
+      [[ -n "${2:-}" ]] || { echo "Error: --agent requires a value"; usage; }
       AGENT_MODE="$2"
       shift 2
       ;;
@@ -63,6 +65,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --context)
+      [[ -n "${2:-}" ]] || { echo "Error: --context requires a value"; usage; }
       CONTEXT_ARGS+=("$2")
       shift 2
       ;;
@@ -98,7 +101,7 @@ fi
 # --- Utility helpers ---
 
 is_number() {
-  [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]
+  [[ "$1" =~ ^[0-9]*\.?[0-9]+$ ]]
 }
 
 json_number_or_null() {
@@ -342,6 +345,7 @@ save_iteration_metrics() {
       output_tokens: .output_tokens,
       cache_read_tokens: .cache_read_tokens,
       cache_creation_tokens: .cache_creation_tokens,
+      context_window: .context_window,
       cost_usd: .cost_usd
     }' > "$metrics_file"
 }
@@ -426,6 +430,7 @@ summarize_run() {
     --argjson completed "$completed" \
     --argjson iterations "$iteration_count" \
     --argjson total_duration_ms "$total_duration_ms" \
+    --argjson total_duration_api_ms "$(json_number_or_null "$( [ "$api_duration_available" = true ] && echo "$total_duration_api_ms" || echo "")")" \
     --argjson total_turns "$total_turns" \
     --argjson total_input "$total_input" \
     --argjson total_output "$total_output" \
@@ -439,6 +444,7 @@ summarize_run() {
       completed: $completed,
       iterations: $iterations,
       total_duration_ms: $total_duration_ms,
+      total_duration_api_ms: $total_duration_api_ms,
       total_turns: $total_turns,
       total_input_tokens: $total_input,
       total_output_tokens: $total_output,

--- a/ralph.sh
+++ b/ralph.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 # Ralph - Autonomous AI agent loop for feature implementation
-# Usage: ./ralph.sh --prd <name> [options] [max_iterations] [prompt_file]
+# Usage: ./ralph.sh --prd <name> [--agent auto|claude|codex] [options] [max_iterations] [prompt_file]
 #
 # Required:
 #   --prd <name>      Feature/workspace name (e.g., "my-feature")
 #                     Creates workspace at ralph/workspaces/<name>/
 #
-# Arguments:
-#   max_iterations    Maximum number of iterations (default: 10)
-#   prompt_file       Path to custom prompt file (default: prompts/agent.md)
-#
 # Options:
-#   --context <path>  Add context file or directory (repeatable)
-#                     Files are listed in the prompt for the agent to read.
-#                     Directories are recursively expanded to all files within.
+#   --agent <mode>      Agent backend: auto (default), claude, or codex
+#                       auto prefers claude when available, then codex.
+#   --context <path>    Add context file or directory (repeatable)
+#                       Files are listed in the prompt for the agent to read.
+#                       Directories are recursively expanded to all files within.
+#   --no-multi-agent    Disable Codex multi-agent sub-spawning
 
 set -e
 
@@ -25,6 +24,21 @@ MAX_ITERATIONS=10
 PROMPT_FILE=""
 CONTEXT_ARGS=()
 PRD_NAME=""
+AGENT_MODE="auto"
+MULTI_AGENT=true
+
+usage() {
+  echo "Usage: ./ralph.sh --prd <name> [--agent auto|claude|codex] [max_iterations] [prompt_file] [--context <path>...]"
+  echo ""
+  echo "Required:"
+  echo "  --prd <name>      Feature/workspace name"
+  echo ""
+  echo "Options:"
+  echo "  --agent <mode>      Agent backend: auto (default), claude, or codex"
+  echo "  --context <path>    Add context file or directory (repeatable)"
+  echo "  --no-multi-agent    Disable Codex multi-agent sub-spawning"
+  exit 1
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -34,6 +48,18 @@ while [[ $# -gt 0 ]]; do
       ;;
     --prd=*)
       PRD_NAME="${1#*=}"
+      shift
+      ;;
+    --agent)
+      AGENT_MODE="$2"
+      shift 2
+      ;;
+    --agent=*)
+      AGENT_MODE="${1#*=}"
+      shift
+      ;;
+    --no-multi-agent)
+      MULTI_AGENT=false
       shift
       ;;
     --context)
@@ -59,8 +85,7 @@ done
 # Validate --prd is provided
 if [ -z "$PRD_NAME" ]; then
   echo "Error: --prd <name> is required"
-  echo "Usage: ./ralph.sh --prd <name> [max_iterations] [prompt_file] [--context <path>...]"
-  exit 1
+  usage
 fi
 
 # Default prompt file
@@ -69,6 +94,65 @@ if [ -z "$PROMPT_FILE" ]; then
 elif [[ "$PROMPT_FILE" != /* ]]; then
   PROMPT_FILE="$(pwd)/$PROMPT_FILE"
 fi
+
+# --- Utility helpers ---
+
+is_number() {
+  [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]
+}
+
+json_number_or_null() {
+  local value="${1:-}"
+  if is_number "$value"; then
+    printf "%s" "$value"
+  else
+    printf "null"
+  fi
+}
+
+# Function to format seconds as human readable time
+format_time() {
+  local total_sec=$1
+  local hours=$((total_sec / 3600))
+  local minutes=$(((total_sec % 3600) / 60))
+  local seconds=$((total_sec % 60))
+
+  if [ $hours -gt 0 ]; then
+    printf "%dh %dm %ds" $hours $minutes $seconds
+  elif [ $minutes -gt 0 ]; then
+    printf "%dm %ds" $minutes $seconds
+  else
+    printf "%ds" $seconds
+  fi
+}
+
+format_optional_time() {
+  local duration_ms="${1:-}"
+  if [[ -z "$duration_ms" || "$duration_ms" == "null" ]] || ! [[ "$duration_ms" =~ ^[0-9]+$ ]]; then
+    printf "n/a"
+    return
+  fi
+  format_time "$((duration_ms / 1000))"
+}
+
+empty_metrics_json() {
+  local provider="$1"
+  local duration_ms="$2"
+  cat <<EOF
+{
+  "provider": "$provider",
+  "duration_ms": $duration_ms,
+  "duration_api_ms": null,
+  "num_turns": 0,
+  "input_tokens": 0,
+  "output_tokens": 0,
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "context_window": null,
+  "cost_usd": null
+}
+EOF
+}
 
 # Resolve context paths and build context section
 resolve_context() {
@@ -106,20 +190,56 @@ resolve_context() {
 
 resolve_context
 
-# Workspace paths — all per-feature files live here
+# --- Dependency checks ---
+
+for cmd in jq bc; do
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "Error: Required dependency '$cmd' is not available on PATH"
+    exit 1
+  }
+done
+
+# --- Agent selection ---
+
+SELECTED_AGENT=""
+
+select_agent() {
+  case "$AGENT_MODE" in
+    auto)
+      if command -v claude >/dev/null 2>&1; then
+        SELECTED_AGENT="claude"
+      elif command -v codex >/dev/null 2>&1; then
+        SELECTED_AGENT="codex"
+      else
+        echo "Error: Neither claude nor codex CLI is available on PATH"
+        exit 1
+      fi
+      ;;
+    claude|codex)
+      command -v "$AGENT_MODE" >/dev/null 2>&1 || {
+        echo "Error: Requested agent '$AGENT_MODE' is not available on PATH"
+        exit 1
+      }
+      SELECTED_AGENT="$AGENT_MODE"
+      ;;
+    *)
+      echo "Error: Invalid --agent value '$AGENT_MODE'. Use auto, claude, or codex."
+      exit 1
+      ;;
+  esac
+}
+
+# --- Workspace setup ---
+
 WORKSPACE_DIR="$RALPH_DIR/workspaces/$PRD_NAME"
 mkdir -p "$WORKSPACE_DIR"
 
 PRD_FILE="$WORKSPACE_DIR/prd.json"
 PROGRESS_FILE="$WORKSPACE_DIR/progress.txt"
-ARCHIVE_DIR="$RALPH_DIR/archive"
 
-# Workspace-relative path (for prompt substitution, relative to project root)
-# Detect the relative path from the project root to the workspace
 PROJECT_ROOT="$(pwd)"
-WORKSPACE_REL="${WORKSPACE_DIR#$PROJECT_ROOT/}"
+WORKSPACE_REL="${WORKSPACE_DIR#"$PROJECT_ROOT"/}"
 
-# Metrics tracking
 RUN_ID=$(date +%Y%m%d_%H%M%S)
 METRICS_DIR="$WORKSPACE_DIR/runs/$RUN_ID"
 CUMULATIVE_FILE="$WORKSPACE_DIR/ralph_runs_cumulative.json"
@@ -146,54 +266,41 @@ if [ ! -f "$PRD_FILE" ]; then
   exit 1
 fi
 
+select_agent
+
 echo "Starting Ralph - PRD: $PRD_NAME | Max iterations: $MAX_ITERATIONS"
+echo "Agent: $SELECTED_AGENT"
 echo "Workspace: $WORKSPACE_DIR"
 echo "Using prompt: $PROMPT_FILE"
 
-# Function to format seconds as human readable time
-format_time() {
-  local total_sec=$1
-  local hours=$((total_sec / 3600))
-  local minutes=$(((total_sec % 3600) / 60))
-  local seconds=$((total_sec % 60))
+# --- Diagnostics and metrics ---
 
-  if [ $hours -gt 0 ]; then
-    printf "%dh %dm %ds" $hours $minutes $seconds
-  elif [ $minutes -gt 0 ]; then
-    printf "%dm %ds" $minutes $seconds
-  else
-    printf "%ds" $seconds
-  fi
-}
-
-# Function to print diagnostics from JSON output
 print_diagnostics() {
   local json="$1"
   local iteration="$2"
 
+  local provider=$(echo "$json" | jq -r '.provider // "unknown"')
   local duration_ms=$(echo "$json" | jq -r '.duration_ms // 0')
-  local duration_api_ms=$(echo "$json" | jq -r '.duration_api_ms // 0')
-  local input_tokens=$(echo "$json" | jq -r '.usage.input_tokens // 0')
-  local output_tokens=$(echo "$json" | jq -r '.usage.output_tokens // 0')
-  local cache_read=$(echo "$json" | jq -r '.usage.cache_read_input_tokens // 0')
-  local cache_creation=$(echo "$json" | jq -r '.usage.cache_creation_input_tokens // 0')
-  local cost_usd=$(echo "$json" | jq -r '.total_cost_usd // 0')
-  local context_window=$(echo "$json" | jq -r '.modelUsage | to_entries[0].value.contextWindow // 200000')
+  local duration_api_ms=$(echo "$json" | jq -r '.duration_api_ms // empty')
+  local input_tokens=$(echo "$json" | jq -r '.input_tokens // 0')
+  local output_tokens=$(echo "$json" | jq -r '.output_tokens // 0')
+  local cache_read=$(echo "$json" | jq -r '.cache_read_tokens // 0')
+  local cache_creation=$(echo "$json" | jq -r '.cache_creation_tokens // 0')
+  local cost_usd=$(echo "$json" | jq -r '.cost_usd // empty')
+  local context_window=$(echo "$json" | jq -r '.context_window // empty')
   local num_turns=$(echo "$json" | jq -r '.num_turns // 0')
 
-  local total_input=$((input_tokens + cache_read + cache_creation))
-  local total_tokens=$((total_input + output_tokens))
-  local estimated_context=$((cache_creation + output_tokens))
-  local context_pct=$(echo "scale=1; ($estimated_context * 100) / $context_window" | bc)
+  local time_str=$(format_time $((duration_ms / 1000)))
+  local api_time_str=$(format_optional_time "$duration_api_ms")
 
-  local duration_sec=$((duration_ms / 1000))
-  local duration_api_sec=$((duration_api_ms / 1000))
-  local time_str=$(format_time $duration_sec)
-  local api_time_str=$(format_time $duration_api_sec)
+  local cost_str="n/a"
+  if is_number "$cost_usd"; then
+    cost_str=$(printf '$%.4f' "$cost_usd")
+  fi
 
   echo ""
   echo "┌──────────────────────────────────────────────────┐"
-  printf "│  ITERATION %-2d DIAGNOSTICS                       │\n" "$iteration"
+  printf "│  ITERATION %-2d DIAGNOSTICS (%-6s)              │\n" "$iteration" "$provider"
   echo "├──────────────────────────────────────────────────┤"
   printf "│  ⏱  Time:   %-10s  API: %-10s       │\n" "$time_str" "$api_time_str"
   printf "│  🔄 Turns:  %-3d                                 │\n" "$num_turns"
@@ -203,43 +310,42 @@ print_diagnostics() {
   printf "│  💾 Cache read:  %8d tokens               │\n" "$cache_read"
   printf "│  📝 Cache new:   %8d tokens               │\n" "$cache_creation"
   echo "├──────────────────────────────────────────────────┤"
-  printf "│  📈 Context:     ~%5.1f%% of %dk               │\n" "$context_pct" "$((context_window / 1000))"
-  printf "│  💰 Cost:        \$%-7.4f                      │\n" "$cost_usd"
+
+  if is_number "$context_window" && [ "$context_window" -gt 0 ]; then
+    local estimated_context=$((cache_creation + output_tokens))
+    local context_pct=$(echo "scale=1; ($estimated_context * 100) / $context_window" | bc)
+    printf "│  📈 Context:     ~%5.1f%% of %dk               │\n" "$context_pct" "$((context_window / 1000))"
+  else
+    printf "│  📈 Context:     %-33s │\n" "n/a"
+  fi
+
+  printf "│  💰 Cost:        %-33s │\n" "$cost_str"
   echo "└──────────────────────────────────────────────────┘"
 }
 
-# Function to save iteration metrics to JSON
 save_iteration_metrics() {
   local json="$1"
   local iteration="$2"
-  local metrics_file="$METRICS_DIR/iteration_$(printf '%03d' $iteration).json"
+  local metrics_file="$METRICS_DIR/iteration_$(printf '%03d' "$iteration").json"
 
-  local duration_ms=$(echo "$json" | jq -r '.duration_ms // 0')
-  local duration_api_ms=$(echo "$json" | jq -r '.duration_api_ms // 0')
-  local input_tokens=$(echo "$json" | jq -r '.usage.input_tokens // 0')
-  local output_tokens=$(echo "$json" | jq -r '.usage.output_tokens // 0')
-  local cache_read=$(echo "$json" | jq -r '.usage.cache_read_input_tokens // 0')
-  local cache_creation=$(echo "$json" | jq -r '.usage.cache_creation_input_tokens // 0')
-  local cost_usd=$(echo "$json" | jq -r '.total_cost_usd // 0')
-  local num_turns=$(echo "$json" | jq -r '.num_turns // 0')
-
-  cat > "$metrics_file" <<EOF
-{
-  "iteration": $iteration,
-  "timestamp": "$(date -Iseconds)",
-  "duration_ms": $duration_ms,
-  "duration_api_ms": $duration_api_ms,
-  "num_turns": $num_turns,
-  "input_tokens": $input_tokens,
-  "output_tokens": $output_tokens,
-  "cache_read_tokens": $cache_read,
-  "cache_creation_tokens": $cache_creation,
-  "cost_usd": $cost_usd
-}
-EOF
+  echo "$json" | jq \
+    --argjson iteration "$iteration" \
+    --arg timestamp "$(date -Iseconds)" '
+    {
+      iteration: $iteration,
+      provider: .provider,
+      timestamp: $timestamp,
+      duration_ms: .duration_ms,
+      duration_api_ms: .duration_api_ms,
+      num_turns: .num_turns,
+      input_tokens: .input_tokens,
+      output_tokens: .output_tokens,
+      cache_read_tokens: .cache_read_tokens,
+      cache_creation_tokens: .cache_creation_tokens,
+      cost_usd: .cost_usd
+    }' > "$metrics_file"
 }
 
-# Function to summarize run and update cumulative file
 summarize_run() {
   local completed=$1
   local total_iterations=$2
@@ -253,27 +359,48 @@ summarize_run() {
   local total_cost=0
   local total_turns=0
   local iteration_count=0
+  local cost_metrics_complete=true
+  local api_duration_available=true
 
   for f in "$METRICS_DIR"/iteration_*.json; do
     [ -f "$f" ] || continue
+
     total_duration_ms=$((total_duration_ms + $(jq -r '.duration_ms // 0' "$f")))
-    total_duration_api_ms=$((total_duration_api_ms + $(jq -r '.duration_api_ms // 0' "$f")))
     total_input=$((total_input + $(jq -r '.input_tokens // 0' "$f")))
     total_output=$((total_output + $(jq -r '.output_tokens // 0' "$f")))
     total_cache_read=$((total_cache_read + $(jq -r '.cache_read_tokens // 0' "$f")))
     total_cache_creation=$((total_cache_creation + $(jq -r '.cache_creation_tokens // 0' "$f")))
-    total_cost=$(echo "$total_cost + $(jq -r '.cost_usd // 0' "$f")" | bc)
     total_turns=$((total_turns + $(jq -r '.num_turns // 0' "$f")))
     iteration_count=$((iteration_count + 1))
+
+    local iter_api_dur
+    iter_api_dur=$(jq -r '.duration_api_ms // empty' "$f")
+    if is_number "$iter_api_dur"; then
+      total_duration_api_ms=$((total_duration_api_ms + iter_api_dur))
+    else
+      api_duration_available=false
+    fi
+
+    local iter_cost
+    iter_cost=$(jq -r '.cost_usd // empty' "$f")
+    if is_number "$iter_cost"; then
+      total_cost=$(echo "$total_cost + $iter_cost" | bc)
+    else
+      cost_metrics_complete=false
+    fi
   done
 
   local total_time_str=$(format_time $((total_duration_ms / 1000)))
-  local total_api_time_str=$(format_time $((total_duration_api_ms / 1000)))
+  local total_api_time_str="n/a"
+  if [ "$api_duration_available" = true ]; then
+    total_api_time_str=$(format_time $((total_duration_api_ms / 1000)))
+  fi
 
   echo ""
   echo "╔══════════════════════════════════════════════════╗"
   echo "║            RUN SUMMARY ($RUN_ID)           ║"
   echo "╠══════════════════════════════════════════════════╣"
+  printf "║  Agent:        %-33s ║\n" "$SELECTED_AGENT"
   printf "║  Iterations:   %-3d                              ║\n" "$iteration_count"
   printf "║  Total Time:   %-12s API: %-10s   ║\n" "$total_time_str" "$total_api_time_str"
   printf "║  Total Turns:  %-3d                              ║\n" "$total_turns"
@@ -283,101 +410,305 @@ summarize_run() {
   printf "║  💾 Cache read:  %10d tokens             ║\n" "$total_cache_read"
   printf "║  📝 Cache new:   %10d tokens             ║\n" "$total_cache_creation"
   echo "╠══════════════════════════════════════════════════╣"
-  printf "║  💰 Total Cost:  \$%-8.4f                     ║\n" "$total_cost"
+  if [ "$cost_metrics_complete" = true ]; then
+    printf "║  💰 Total Cost:  \$%-8.4f                     ║\n" "$total_cost"
+  else
+    printf "║  💰 Total Cost:  %-33s ║\n" "n/a"
+  fi
   echo "╚══════════════════════════════════════════════════╝"
   echo ""
   echo "Metrics saved to: $METRICS_DIR"
 
   # Save run summary
-  cat > "$METRICS_DIR/summary.json" <<EOF
-{
-  "run_id": "$RUN_ID",
-  "completed": $completed,
-  "iterations": $iteration_count,
-  "total_duration_ms": $total_duration_ms,
-  "total_duration_api_ms": $total_duration_api_ms,
-  "total_turns": $total_turns,
-  "total_input_tokens": $total_input,
-  "total_output_tokens": $total_output,
-  "total_cache_read_tokens": $total_cache_read,
-  "total_cache_creation_tokens": $total_cache_creation,
-  "total_cost_usd": $total_cost
-}
-EOF
+  jq -n \
+    --arg run_id "$RUN_ID" \
+    --arg provider "$SELECTED_AGENT" \
+    --argjson completed "$completed" \
+    --argjson iterations "$iteration_count" \
+    --argjson total_duration_ms "$total_duration_ms" \
+    --argjson total_turns "$total_turns" \
+    --argjson total_input "$total_input" \
+    --argjson total_output "$total_output" \
+    --argjson total_cache_read "$total_cache_read" \
+    --argjson total_cache_creation "$total_cache_creation" \
+    --argjson cost_usd "$(json_number_or_null "$( [ "$cost_metrics_complete" = true ] && echo "$total_cost" || echo "")")" \
+    --argjson cost_complete "$([ "$cost_metrics_complete" = true ] && echo true || echo false)" '
+    {
+      run_id: $run_id,
+      provider: $provider,
+      completed: $completed,
+      iterations: $iterations,
+      total_duration_ms: $total_duration_ms,
+      total_turns: $total_turns,
+      total_input_tokens: $total_input,
+      total_output_tokens: $total_output,
+      total_cache_read_tokens: $total_cache_read,
+      total_cache_creation_tokens: $total_cache_creation,
+      total_cost_usd: $cost_usd,
+      cost_metrics_complete: $cost_complete
+    }' > "$METRICS_DIR/summary.json"
 
   # Update cumulative file
   if [ -f "$CUMULATIVE_FILE" ]; then
     local prev_runs=$(jq -r '.total_runs // 0' "$CUMULATIVE_FILE")
     local prev_iterations=$(jq -r '.total_iterations // 0' "$CUMULATIVE_FILE")
     local prev_duration=$(jq -r '.total_duration_ms // 0' "$CUMULATIVE_FILE")
-    local prev_cost=$(jq -r '.total_cost_usd // 0' "$CUMULATIVE_FILE")
     local prev_input=$(jq -r '.total_input_tokens // 0' "$CUMULATIVE_FILE")
     local prev_output=$(jq -r '.total_output_tokens // 0' "$CUMULATIVE_FILE")
 
-    cat > "$CUMULATIVE_FILE" <<EOF
-{
-  "total_runs": $((prev_runs + 1)),
-  "total_iterations": $((prev_iterations + iteration_count)),
-  "total_duration_ms": $((prev_duration + total_duration_ms)),
-  "total_input_tokens": $((prev_input + total_input)),
-  "total_output_tokens": $((prev_output + total_output)),
-  "total_cost_usd": $(echo "$prev_cost + $total_cost" | bc),
-  "last_run": "$RUN_ID",
-  "last_updated": "$(date -Iseconds)"
-}
-EOF
+    local prev_cost_complete
+    prev_cost_complete=$(jq -r '.cost_metrics_complete // empty' "$CUMULATIVE_FILE")
+
+    if [ -z "$prev_cost_complete" ] || [ "$prev_cost_complete" = "null" ]; then
+      local prev_cost_val
+      prev_cost_val=$(jq -r '.total_cost_usd // empty' "$CUMULATIVE_FILE")
+      if is_number "$prev_cost_val"; then
+        prev_cost_complete=true
+      else
+        prev_cost_complete=false
+      fi
+    fi
+
+    local cumulative_cost_complete=true
+    if [ "$prev_cost_complete" != "true" ] || [ "$cost_metrics_complete" != "true" ]; then
+      cumulative_cost_complete=false
+    fi
+
+    local prev_cost
+    prev_cost=$(jq -r '.total_cost_usd // empty' "$CUMULATIVE_FILE")
+    local new_total_cost
+    if [ "$cumulative_cost_complete" = true ] && is_number "$prev_cost"; then
+      new_total_cost=$(echo "$prev_cost + $total_cost" | bc)
+    else
+      new_total_cost=""
+    fi
+
+    jq -n \
+      --argjson total_runs "$((prev_runs + 1))" \
+      --argjson total_iterations "$((prev_iterations + iteration_count))" \
+      --argjson total_duration_ms "$((prev_duration + total_duration_ms))" \
+      --argjson total_input "$((prev_input + total_input))" \
+      --argjson total_output "$((prev_output + total_output))" \
+      --argjson cost_usd "$(json_number_or_null "$new_total_cost")" \
+      --argjson cost_complete "$([ "$cumulative_cost_complete" = true ] && echo true || echo false)" \
+      --arg last_provider "$SELECTED_AGENT" \
+      --arg last_run "$RUN_ID" \
+      --arg last_updated "$(date -Iseconds)" '
+      {
+        total_runs: $total_runs,
+        total_iterations: $total_iterations,
+        total_duration_ms: $total_duration_ms,
+        total_input_tokens: $total_input,
+        total_output_tokens: $total_output,
+        total_cost_usd: $cost_usd,
+        cost_metrics_complete: $cost_complete,
+        last_provider: $last_provider,
+        last_run: $last_run,
+        last_updated: $last_updated
+      }' > "$CUMULATIVE_FILE"
   else
-    cat > "$CUMULATIVE_FILE" <<EOF
-{
-  "total_runs": 1,
-  "total_iterations": $iteration_count,
-  "total_duration_ms": $total_duration_ms,
-  "total_input_tokens": $total_input,
-  "total_output_tokens": $total_output,
-  "total_cost_usd": $total_cost,
-  "last_run": "$RUN_ID",
-  "last_updated": "$(date -Iseconds)"
-}
-EOF
+    jq -n \
+      --argjson total_iterations "$iteration_count" \
+      --argjson total_duration_ms "$total_duration_ms" \
+      --argjson total_input "$total_input" \
+      --argjson total_output "$total_output" \
+      --argjson cost_usd "$(json_number_or_null "$( [ "$cost_metrics_complete" = true ] && echo "$total_cost" || echo "")")" \
+      --argjson cost_complete "$([ "$cost_metrics_complete" = true ] && echo true || echo false)" \
+      --arg last_provider "$SELECTED_AGENT" \
+      --arg last_run "$RUN_ID" \
+      --arg last_updated "$(date -Iseconds)" '
+      {
+        total_runs: 1,
+        total_iterations: $total_iterations,
+        total_duration_ms: $total_duration_ms,
+        total_input_tokens: $total_input,
+        total_output_tokens: $total_output,
+        total_cost_usd: $cost_usd,
+        cost_metrics_complete: $cost_complete,
+        last_provider: $last_provider,
+        last_run: $last_run,
+        last_updated: $last_updated
+      }' > "$CUMULATIVE_FILE"
   fi
 }
 
-for i in $(seq 1 $MAX_ITERATIONS); do
+# --- Agent runner functions ---
+
+RESULT=""
+METRICS_JSON=""
+
+run_claude() {
+  local prompt="$1"
+  local iteration="$2"
+  local stdout_file stderr_file
+  stdout_file=$(mktemp)
+  stderr_file=$(mktemp)
+
+  local start_ms end_ms duration_ms
+  start_ms=$(( $(date +%s) * 1000 ))
+  if ! claude -p "$prompt" \
+      --dangerously-skip-permissions \
+      --output-format json >"$stdout_file" 2>"$stderr_file"; then
+    echo "Warning: Claude exited non-zero for iteration $iteration"
+  fi
+  end_ms=$(( $(date +%s) * 1000 ))
+  duration_ms=$((end_ms - start_ms))
+
+  local json_output
+  json_output=$(cat "$stdout_file")
+  RESULT=$(echo "$json_output" | jq -r '.result // empty' 2>/dev/null)
+
+  if [ -s "$stderr_file" ]; then
+    echo "Claude stderr:"
+    sed -n '1,40p' "$stderr_file"
+  fi
+
+  if echo "$json_output" | jq -e '.usage' >/dev/null 2>&1; then
+    METRICS_JSON=$(echo "$json_output" | jq \
+      --arg provider "claude" \
+      --argjson fallback_duration "$duration_ms" '
+      {
+        provider: $provider,
+        duration_ms: (.duration_ms // $fallback_duration),
+        duration_api_ms: (.duration_api_ms // null),
+        num_turns: (.num_turns // 0),
+        input_tokens: (.usage.input_tokens // 0),
+        output_tokens: (.usage.output_tokens // 0),
+        cache_read_tokens: (.usage.cache_read_input_tokens // 0),
+        cache_creation_tokens: (.usage.cache_creation_input_tokens // 0),
+        context_window: ((.modelUsage // {} | to_entries[0].value.contextWindow?) // 200000),
+        cost_usd: (.total_cost_usd // null)
+      }')
+  else
+    METRICS_JSON=$(empty_metrics_json "claude" "$duration_ms")
+  fi
+
+  rm -f "$stdout_file" "$stderr_file"
+}
+
+run_codex() {
+  local prompt="$1"
+  local iteration="$2"
+  local stdout_file stderr_file last_message_file
+  stdout_file=$(mktemp)
+  stderr_file=$(mktemp)
+  last_message_file=$(mktemp)
+
+  local codex_flags=(--skip-git-repo-check --sandbox workspace-write --json --output-last-message "$last_message_file")
+  if [ "$MULTI_AGENT" = true ]; then
+    codex_flags+=(--enable multi_agent)
+  fi
+
+  local start_ms end_ms duration_ms
+  start_ms=$(( $(date +%s) * 1000 ))
+  if ! printf "%s" "$prompt" | codex -a never exec \
+      "${codex_flags[@]}" \
+      - >"$stdout_file" 2>"$stderr_file"; then
+    echo "Warning: Codex exited non-zero for iteration $iteration"
+  fi
+  end_ms=$(( $(date +%s) * 1000 ))
+  duration_ms=$((end_ms - start_ms))
+
+  RESULT=""
+  [ -f "$last_message_file" ] && RESULT=$(cat "$last_message_file")
+
+  if [ -s "$stderr_file" ]; then
+    echo "Codex stderr:"
+    sed -n '1,40p' "$stderr_file"
+  fi
+
+  local usage_json=""
+  if [ -s "$stdout_file" ]; then
+    if ! usage_json=$(jq -s '
+      reduce .[] as $event (
+        {
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_read_tokens: 0,
+          num_turns: 0
+        };
+        if $event.type == "turn.completed" then
+          .input_tokens += ($event.usage.input_tokens // 0) |
+          .output_tokens += ($event.usage.output_tokens // 0) |
+          .cache_read_tokens += ($event.usage.cached_input_tokens // 0) |
+          .num_turns += 1
+        else
+          .
+        end
+      )' "$stdout_file" 2>/dev/null) || [ -z "$usage_json" ]; then
+      echo "Warning: Could not parse Codex JSONL output"
+      sed -n '1,20p' "$stdout_file"
+      usage_json=""
+    fi
+  fi
+
+  if [ -n "$usage_json" ]; then
+    METRICS_JSON=$(echo "$usage_json" | jq \
+      --arg provider "codex" \
+      --argjson duration_ms "$duration_ms" '
+      {
+        provider: $provider,
+        duration_ms: $duration_ms,
+        duration_api_ms: null,
+        num_turns: (.num_turns // 0),
+        input_tokens: (.input_tokens // 0),
+        output_tokens: (.output_tokens // 0),
+        cache_read_tokens: (.cache_read_tokens // 0),
+        cache_creation_tokens: 0,
+        context_window: null,
+        cost_usd: null
+      }')
+  else
+    METRICS_JSON=$(empty_metrics_json "codex" "$duration_ms")
+  fi
+
+  rm -f "$stdout_file" "$stderr_file" "$last_message_file"
+}
+
+run_agent() {
+  local prompt="$1"
+  local iteration="$2"
+
+  RESULT=""
+  METRICS_JSON=""
+
+  case "$SELECTED_AGENT" in
+    claude) run_claude "$prompt" "$iteration" ;;
+    codex)  run_codex "$prompt" "$iteration" ;;
+    *)      echo "Error: Unsupported agent backend: $SELECTED_AGENT"; exit 1 ;;
+  esac
+}
+
+# --- Main iteration loop ---
+
+for i in $(seq 1 "$MAX_ITERATIONS"); do
   echo ""
   echo "═══════════════════════════════════════════════════════"
-  echo "  Ralph Iteration $i of $MAX_ITERATIONS [$PRD_NAME]"
+  echo "  Ralph Iteration $i of $MAX_ITERATIONS [$PRD_NAME] ($SELECTED_AGENT)"
   echo "═══════════════════════════════════════════════════════"
 
-  # Run claude with the ralph prompt and capture JSON output
   PROMPT=$(cat "$PROMPT_FILE")
-  # Substitute placeholders
   PROMPT="${PROMPT//\{\{CONTEXT_SECTION\}\}/$CONTEXT_SECTION}"
   PROMPT="${PROMPT//\{\{WORKSPACE\}\}/$WORKSPACE_REL}"
-  ITERATION_START=$(date +%s)
 
-  JSON_OUTPUT=$(claude -p "$PROMPT" --dangerously-skip-permissions --output-format json 2>&1) || true
+  run_agent "$PROMPT" "$i"
 
-  # Extract and display the result text
-  RESULT=$(echo "$JSON_OUTPUT" | jq -r '.result // empty' 2>/dev/null)
   if [ -n "$RESULT" ]; then
     echo ""
     echo "$RESULT"
   fi
 
-  # Print diagnostics and save metrics
-  if echo "$JSON_OUTPUT" | jq -e '.duration_ms' > /dev/null 2>&1; then
-    print_diagnostics "$JSON_OUTPUT" "$i"
-    save_iteration_metrics "$JSON_OUTPUT" "$i"
+  if [ -n "$METRICS_JSON" ] && echo "$METRICS_JSON" | jq -e '.duration_ms' > /dev/null 2>&1; then
+    print_diagnostics "$METRICS_JSON" "$i"
+    save_iteration_metrics "$METRICS_JSON" "$i"
   else
     echo ""
-    echo "⚠️  Could not parse diagnostics from output"
-    echo "$JSON_OUTPUT" | head -20
+    echo "Warning: Could not parse diagnostics from output"
   fi
 
-  # Check for completion signal
   if echo "$RESULT" | grep -q "<promise>COMPLETE</promise>"; then
     echo ""
-    echo "✅ Ralph completed all tasks!"
+    echo "Ralph completed all tasks!"
     echo "Completed at iteration $i of $MAX_ITERATIONS"
     summarize_run true "$i"
     exit 0


### PR DESCRIPTION
## Summary

- Adds `--agent auto|claude|codex` flag to select agent backend (auto-detect by default, prefers Claude when both available)
- Extracts inline Claude invocation into `run_claude()` function with separated stdout/stderr (fixes JSON parsing corruption from merged streams)
- Adds `run_codex()` function: stdin prompt delivery, JSONL event stream parsing, `--output-last-message` for result text, `--sandbox workspace-write` for safe file access
- Normalizes metrics contract across both providers — nullable fields (`cost_usd`, `duration_api_ms`, `context_window`) stored as JSON `null` for Codex, displayed as "n/a"
- Adds `--no-multi-agent` flag to disable Codex sub-agent spawning
- Adds `usage()` helper and startup dependency checks for `jq`/`bc`
- Updates cumulative metrics file with backward-compatible migration for pre-existing files
- Makes agent prompt session ID discovery conditional (Claude Code only)

## Changed files

| File | Changes |
|------|---------|
| `ralph.sh` | ~500 lines new/refactored: flag parsing, agent functions, normalized metrics |
| `prompts/agent.md` | Session ID section conditional, CLAUDE.md clarification |
| `CLAUDE.md` | Added `--agent` examples to Commands section |
| `README.md` | Documented agent selection, Codex requirements, metric differences |

## Test plan

- [ ] `bash -n ralph.sh` passes (verified)
- [ ] `./ralph.sh --prd test --agent claude 1` preserves existing Claude behavior
- [ ] `./ralph.sh --prd test --agent codex 1` invokes Codex with correct flags
- [ ] `./ralph.sh --prd test --agent auto 1` auto-detects available agent
- [ ] `./ralph.sh --prd test --agent nope 1` shows "Invalid --agent value" error
- [ ] `./ralph.sh` (no --prd) shows usage help
- [ ] Codex metrics show "n/a" for cost, API time, context window
- [ ] Claude metrics show dollar values and percentages as before
- [ ] Cumulative file handles mixed-provider runs (cost_metrics_complete tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)