### PR TITLE
Minimal frontend dashboard for ralph workspaces

### DIFF
--- a/ralph-v2/dashboard/dashboard.sh
+++ b/ralph-v2/dashboard/dashboard.sh
@@ -8,6 +8,7 @@ usage() {
   cat >&2 <<'USAGE'
 Usage:
   dashboard.sh aggregate [--workspaces-dir <path>]
+  dashboard.sh serve [--port <N>] [--workspaces-dir <path>]
 USAGE
 }
 
@@ -39,6 +40,11 @@ aggregate() {
   local workspaces_dir workspaces_file warnings_file state_file
 
   workspaces_dir="$(resolve_workspaces_dir "$@")"
+  if [[ ! -d "$workspaces_dir" ]]; then
+    echo "Error: workspaces directory does not exist or is not a directory: $workspaces_dir" >&2
+    return 1
+  fi
+
   workspaces_file="$(mktemp)"
   warnings_file="$(mktemp)"
 
@@ -131,6 +137,140 @@ aggregate() {
   rm -f "$workspaces_file" "$warnings_file"
 }
 
+serve() {
+  local port="8080"
+  local workspaces_dir
+
+  workspaces_dir="$(resolve_workspaces_dir)"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --port)
+        [[ $# -ge 2 ]] || {
+          echo "Error: --port requires a value" >&2
+          return 1
+        }
+        port="$2"
+        shift 2
+        ;;
+      --workspaces-dir)
+        [[ $# -ge 2 ]] || {
+          echo "Error: --workspaces-dir requires a path" >&2
+          return 1
+        }
+        workspaces_dir="$2"
+        shift 2
+        ;;
+      *)
+        echo "Error: unknown serve option: $1" >&2
+        usage
+        return 1
+        ;;
+    esac
+  done
+
+  command -v python3 >/dev/null 2>&1 || {
+    echo "Error: python3 is required for dashboard.sh serve" >&2
+    return 1
+  }
+  command -v jq >/dev/null 2>&1 || {
+    echo "Error: jq is required for dashboard.sh serve" >&2
+    return 1
+  }
+
+  echo "Dashboard: http://127.0.0.1:$port"
+  DASHBOARD_SCRIPT="$SCRIPT_DIR/dashboard.sh" DASHBOARD_DIR="$SCRIPT_DIR" RALPH_DASHBOARD_WORKSPACES_DIR="$workspaces_dir" RALPH_DASHBOARD_PORT="$port" python3 <<'PYTHON'
+import json
+import mimetypes
+import os
+import subprocess
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+
+dashboard_script = os.environ["DASHBOARD_SCRIPT"]
+dashboard_dir = Path(os.environ["DASHBOARD_DIR"]).resolve()
+workspaces_dir = os.environ["RALPH_DASHBOARD_WORKSPACES_DIR"]
+port = int(os.environ["RALPH_DASHBOARD_PORT"])
+
+
+def fully_unquote(path):
+    decoded = path
+    for _ in range(5):
+        next_decoded = unquote(decoded)
+        if next_decoded == decoded:
+            return decoded
+        decoded = next_decoded
+    return decoded
+
+
+class DashboardHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/workspaces":
+            self.serve_workspaces()
+            return
+        self.serve_static(parsed.path)
+
+    def serve_workspaces(self):
+        result = subprocess.run(
+            [dashboard_script, "aggregate", "--workspaces-dir", workspaces_dir],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            message = result.stderr.strip() or result.stdout.strip() or "aggregate command failed"
+            self.send_json(500, {"error": "aggregate failed", "details": message})
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(result.stdout.encode("utf-8"))
+
+    def serve_static(self, raw_path):
+        decoded_path = fully_unquote(raw_path)
+        if "../" in decoded_path or decoded_path.startswith(".."):
+            self.send_error(403)
+            return
+
+        relative_path = "index.html" if decoded_path in ("", "/") else decoded_path.lstrip("/")
+        target = (dashboard_dir / relative_path).resolve()
+        if dashboard_dir not in target.parents and target != dashboard_dir:
+            self.send_error(403)
+            return
+        if not target.is_file():
+            self.send_error(404)
+            return
+
+        content_type = mimetypes.guess_type(str(target))[0] or "application/octet-stream"
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.end_headers()
+        self.wfile.write(target.read_bytes())
+
+    def send_json(self, status, payload):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        return
+
+
+try:
+    HTTPServer(("127.0.0.1", port), DashboardHandler).serve_forever()
+except KeyboardInterrupt:
+    sys.exit(0)
+PYTHON
+}
+
 main() {
   local command="${1:-}"
 
@@ -138,6 +278,10 @@ main() {
     aggregate)
       shift
       aggregate "$@"
+      ;;
+    serve)
+      shift
+      serve "$@"
       ;;
     *)
       usage

--- a/ralph-v2/dashboard/dashboard.sh
+++ b/ralph-v2/dashboard/dashboard.sh
@@ -91,7 +91,7 @@ aggregate() {
         if any(.steps[]; .status == "failed") then "failed"
         elif any(.steps[]; .status == "blocked") then "blocked"
         elif any(.steps[]; .status == "in_progress") then "in_progress"
-        elif all(.steps[]; .status == "completed") then "completed"
+        elif ((.steps | length) > 0) and all(.steps[]; .status == "completed") then "completed"
         else "pending"
         end;
 
@@ -139,9 +139,7 @@ aggregate() {
 
 serve() {
   local port="8080"
-  local workspaces_dir
-
-  workspaces_dir="$(resolve_workspaces_dir)"
+  local workspaces_dir=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -168,6 +166,15 @@ serve() {
         ;;
     esac
   done
+
+  if [[ -z "$workspaces_dir" ]]; then
+    workspaces_dir="${RALPH_WORKSPACES_DIR:-$DEFAULT_WORKSPACES_DIR}"
+  fi
+
+  if [[ ! -d "$workspaces_dir" ]]; then
+    echo "Error: workspaces directory does not exist or is not a directory: $workspaces_dir" >&2
+    return 1
+  fi
 
   command -v python3 >/dev/null 2>&1 || {
     echo "Error: python3 is required for dashboard.sh serve" >&2

--- a/ralph-v2/dashboard/dashboard.sh
+++ b/ralph-v2/dashboard/dashboard.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_WORKSPACES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/workspaces"
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  dashboard.sh aggregate [--workspaces-dir <path>]
+USAGE
+}
+
+resolve_workspaces_dir() {
+  local workspaces_dir="${RALPH_WORKSPACES_DIR:-$DEFAULT_WORKSPACES_DIR}"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --workspaces-dir)
+        [[ $# -ge 2 ]] || {
+          echo "Error: --workspaces-dir requires a path" >&2
+          return 1
+        }
+        workspaces_dir="$2"
+        shift 2
+        ;;
+      *)
+        echo "Error: unknown aggregate option: $1" >&2
+        usage
+        return 1
+        ;;
+    esac
+  done
+
+  printf '%s\n' "$workspaces_dir"
+}
+
+aggregate() {
+  local workspaces_dir workspaces_file warnings_file state_file
+
+  workspaces_dir="$(resolve_workspaces_dir "$@")"
+  workspaces_file="$(mktemp)"
+  warnings_file="$(mktemp)"
+
+  shopt -s nullglob
+  for state_file in "$workspaces_dir"/*/state.json; do
+    if ! jq empty "$state_file" >/dev/null 2>&1; then
+      jq -Rn --arg warning "$state_file: invalid JSON" '$warning' >> "$warnings_file"
+      continue
+    fi
+
+    if ! jq -e '(.issue | type) == "number"' "$state_file" >/dev/null; then
+      jq -Rn --arg warning "$state_file: .issue must be numeric" '$warning' >> "$warnings_file"
+      continue
+    fi
+
+    if ! jq -e '(.steps | type) == "array"' "$state_file" >/dev/null; then
+      jq -Rn --arg warning "$state_file: .steps must be an array" '$warning' >> "$warnings_file"
+      continue
+    fi
+
+    if ! jq -e '
+      all(.steps[]; (.status // null) as $status
+        | ["pending", "in_progress", "completed", "blocked", "failed"] | index($status))
+    ' "$state_file" >/dev/null; then
+      jq -Rn --arg warning "$state_file: step status must be one of pending, in_progress, completed, blocked, failed" '$warning' >> "$warnings_file"
+      continue
+    fi
+
+    jq -c '
+      def step_count($status):
+        [.steps[] | select(.status == $status)] | length;
+
+      def first_step_id($status):
+        first(.steps[]? | select(.status == $status) | .id) // null;
+
+      def current_step:
+        first_step_id("failed")
+        // first_step_id("blocked")
+        // first_step_id("in_progress")
+        // first_step_id("pending")
+        // (last(.steps[]? | .id) // null);
+
+      def derived_status:
+        if any(.steps[]; .status == "failed") then "failed"
+        elif any(.steps[]; .status == "blocked") then "blocked"
+        elif any(.steps[]; .status == "in_progress") then "in_progress"
+        elif all(.steps[]; .status == "completed") then "completed"
+        else "pending"
+        end;
+
+      def total_cost:
+        [.steps[] | .metrics.cost_usd? | select(. != null)] as $costs
+        | if ($costs | length) == 0 then null else ($costs | add) end;
+
+      {
+        issue,
+        repo: (.repo // ""),
+        branch: (.branch // ""),
+        createdAt: (.createdAt // ""),
+        derivedStatus: derived_status,
+        currentStep: current_step,
+        steps: [
+          .steps[] | {
+            id,
+            type,
+            agent,
+            status,
+            duration_ms: (.metrics.duration_ms // 0),
+            cost_usd: (.metrics.cost_usd // null)
+          }
+        ],
+        totalDuration_ms: ([.steps[] | .metrics.duration_ms? // 0] | add // 0),
+        totalCost_usd: total_cost,
+        stepCounts: {
+          completed: step_count("completed"),
+          pending: step_count("pending"),
+          in_progress: step_count("in_progress"),
+          blocked: step_count("blocked"),
+          failed: step_count("failed")
+        }
+      }
+    ' "$state_file" >> "$workspaces_file"
+  done
+  shopt -u nullglob
+
+  jq -n \
+    --slurpfile workspaces "$workspaces_file" \
+    --slurpfile warnings "$warnings_file" \
+    '{workspaces: ($workspaces | sort_by(.issue)), warnings: $warnings}'
+  rm -f "$workspaces_file" "$warnings_file"
+}
+
+main() {
+  local command="${1:-}"
+
+  case "$command" in
+    aggregate)
+      shift
+      aggregate "$@"
+      ;;
+    *)
+      usage
+      return 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/ralph-v2/dashboard/index.html
+++ b/ralph-v2/dashboard/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Ralph Pipeline Dashboard</title>
+    <link rel="stylesheet" href="/style.css">
+  </head>
+  <body>
+    <main>
+      <header class="page-header">
+        <h1>Pipeline Dashboard</h1>
+        <button id="refresh-button" type="button">Refresh</button>
+      </header>
+      <section id="dashboard-content" aria-live="polite"></section>
+    </main>
+    <script>
+      async function loadPipelines() {
+        const content = document.getElementById('dashboard-content');
+        content.textContent = 'Loading Pipelines...';
+        const response = await fetch('/api/workspaces');
+        const data = await response.json();
+
+        if (!data.workspaces || data.workspaces.length === 0) {
+          content.innerHTML = '<p class="empty-state">No active Pipelines found.</p>';
+          return;
+        }
+
+        content.innerHTML = '<table><thead><tr><th>Issue #</th><th>Repo</th><th>Branch</th><th>Status</th><th>Current Step</th><th>Steps Progress</th><th>Duration</th><th>Cost</th></tr></thead><tbody></tbody></table>';
+        const tbody = content.querySelector('tbody');
+        data.workspaces.forEach((workspace) => {
+          const row = document.createElement('tr');
+          const status = workspace.derivedStatus || 'pending';
+          row.innerHTML = `
+            <td>${escapeHtml(workspace.issue)}</td>
+            <td>${escapeHtml(workspace.repo)}</td>
+            <td>${escapeHtml(workspace.branch)}</td>
+            <td><span class="status status-${status}">${escapeHtml(status)}</span></td>
+            <td>${escapeHtml(workspace.currentStep || 'n/a')}</td>
+            <td>${renderStepProgress(workspace.steps || [])}</td>
+            <td>${formatDuration(workspace.totalDuration_ms || 0)}</td>
+            <td>${formatCost(workspace.totalCost_usd)}</td>
+          `;
+          tbody.appendChild(row);
+        });
+      }
+
+      function renderStepProgress(steps) {
+        return `<div class="step-progress" aria-label="${steps.length} Steps">${steps.map((step) => `<span class="step-segment status-${step.status}" title="${escapeHtml(step.id)}: ${escapeHtml(step.status)}"></span>`).join('')}</div>`;
+      }
+
+      function escapeHtml(value) {
+        return String(value ?? '').replace(/[&<>"']/g, (character) => ({
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;'
+        }[character]));
+      }
+
+      function formatDuration(durationMs) {
+        const totalSeconds = Math.floor(durationMs / 1000);
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = totalSeconds % 60;
+        if (minutes > 0) {
+          return `${minutes}m ${seconds}s`;
+        }
+        return `${seconds}s`;
+      }
+
+      function formatCost(cost) {
+        return cost == null ? 'n/a' : `$${Number(cost).toFixed(2)}`;
+      }
+
+      document.getElementById('refresh-button').addEventListener('click', loadPipelines);
+      loadPipelines();
+    </script>
+  </body>
+</html>

--- a/ralph-v2/dashboard/index.html
+++ b/ralph-v2/dashboard/index.html
@@ -12,14 +12,42 @@
         <h1>Pipeline Dashboard</h1>
         <button id="refresh-button" type="button">Refresh</button>
       </header>
+      <section id="dashboard-error" class="error-message" aria-live="polite" hidden></section>
+      <section id="warnings-banner" class="warnings-banner" aria-live="polite" hidden></section>
       <section id="dashboard-content" aria-live="polite"></section>
     </main>
     <script>
       async function loadPipelines() {
         const content = document.getElementById('dashboard-content');
+        clearError();
+        renderWarnings([]);
         content.textContent = 'Loading Pipelines...';
-        const response = await fetch('/api/workspaces');
-        const data = await response.json();
+
+        let response;
+        try {
+          response = await fetch('/api/workspaces');
+        } catch (error) {
+          showError(`Unable to connect to the dashboard server. ${error.message}`);
+          content.textContent = '';
+          return;
+        }
+
+        if (!response.ok) {
+          showError(`Unable to load Pipeline data. Server returned HTTP ${response.status}.`);
+          content.textContent = '';
+          return;
+        }
+
+        let data;
+        try {
+          data = await response.json();
+        } catch (error) {
+          showError('Unable to parse Pipeline data. The server returned invalid JSON.');
+          content.textContent = '';
+          return;
+        }
+
+        renderWarnings(data.warnings || []);
 
         if (!data.workspaces || data.workspaces.length === 0) {
           content.innerHTML = '<p class="empty-state">No active Pipelines found.</p>';
@@ -31,6 +59,11 @@
         data.workspaces.forEach((workspace) => {
           const row = document.createElement('tr');
           const status = workspace.derivedStatus || 'pending';
+          row.className = 'pipeline-row';
+          row.setAttribute('data-pipeline-row', String(workspace.issue));
+          row.setAttribute('role', 'button');
+          row.setAttribute('tabindex', '0');
+          row.setAttribute('aria-expanded', 'false');
           row.innerHTML = `
             <td>${escapeHtml(workspace.issue)}</td>
             <td>${escapeHtml(workspace.repo)}</td>
@@ -41,8 +74,98 @@
             <td>${formatDuration(workspace.totalDuration_ms || 0)}</td>
             <td>${formatCost(workspace.totalCost_usd)}</td>
           `;
+          row.addEventListener('click', () => togglePipelineDetails(row, workspace));
+          row.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              togglePipelineDetails(row, workspace);
+            }
+          });
           tbody.appendChild(row);
         });
+      }
+
+      function renderWarnings(warnings) {
+        const banner = document.getElementById('warnings-banner');
+        if (!warnings.length) {
+          banner.hidden = true;
+          banner.innerHTML = '';
+          return;
+        }
+
+        banner.hidden = false;
+        banner.innerHTML = `
+          <h2>Workspace Warnings</h2>
+          <ul></ul>
+        `;
+        const list = banner.querySelector('ul');
+        warnings.forEach((warning) => {
+          const item = document.createElement('li');
+          item.textContent = warning;
+          list.appendChild(item);
+        });
+      }
+
+      function showError(message) {
+        const error = document.getElementById('dashboard-error');
+        error.textContent = message;
+        error.hidden = false;
+      }
+
+      function clearError() {
+        const error = document.getElementById('dashboard-error');
+        error.textContent = '';
+        error.hidden = true;
+      }
+
+      function togglePipelineDetails(row, workspace) {
+        const nextRow = row.nextElementSibling;
+        if (nextRow && nextRow.classList.contains('pipeline-details-row')) {
+          nextRow.remove();
+          row.setAttribute('aria-expanded', 'false');
+          return;
+        }
+
+        const detailRow = document.createElement('tr');
+        detailRow.className = 'pipeline-details-row';
+        detailRow.innerHTML = `<td colspan="8">${renderStepDetails(workspace.steps || [])}</td>`;
+        row.after(detailRow);
+        row.setAttribute('aria-expanded', 'true');
+      }
+
+      function renderStepDetails(steps) {
+        if (!steps.length) {
+          return '<p class="empty-details">No Steps recorded.</p>';
+        }
+
+        return `
+          <div class="step-details">
+            <table>
+              <thead>
+                <tr>
+                  <th>Step ID</th>
+                  <th>Type</th>
+                  <th>Agent</th>
+                  <th>Status</th>
+                  <th>Duration</th>
+                  <th>Cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${steps.map((step) => `
+                  <tr>
+                    <td>${escapeHtml(step.id || 'n/a')}</td>
+                    <td>${escapeHtml(step.type || 'n/a')}</td>
+                    <td>${escapeHtml(step.agent || 'n/a')}</td>
+                    <td><span class="status status-${step.status || 'pending'}">${escapeHtml(step.status || 'pending')}</span></td>
+                    <td>${formatDuration(step.duration_ms || 0)}</td>
+                    <td>${formatCost(step.cost_usd)}</td>
+                  </tr>
+                `).join('')}
+              </tbody>
+            </table>
+          </div>
+        `;
       }
 
       function renderStepProgress(steps) {

--- a/ralph-v2/dashboard/style.css
+++ b/ralph-v2/dashboard/style.css
@@ -1,0 +1,113 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #f6f8fa;
+  color: #1f2328;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+main {
+  width: min(1180px, calc(100vw - 32px));
+  margin: 32px auto;
+}
+
+.page-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+h1 {
+  font-size: 28px;
+  font-weight: 650;
+  margin: 0;
+}
+
+button {
+  background: #0969da;
+  border: 0;
+  border-radius: 6px;
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  padding: 8px 14px;
+}
+
+table {
+  background: #ffffff;
+  border: 1px solid #d0d7de;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th,
+td {
+  border-bottom: 1px solid #d0d7de;
+  padding: 10px 12px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+th {
+  background: #f6f8fa;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.status {
+  border-radius: 999px;
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 650;
+  padding: 3px 8px;
+}
+
+.status-completed {
+  background: #dafbe1;
+  color: #116329;
+}
+
+.status-in_progress {
+  background: #ddf4ff;
+  color: #0969da;
+}
+
+.status-blocked {
+  background: #fff8c5;
+  color: #9a6700;
+}
+
+.status-failed {
+  background: #ffebe9;
+  color: #cf222e;
+}
+
+.status-pending {
+  background: #eaeef2;
+  color: #57606a;
+}
+
+.step-progress {
+  display: flex;
+  gap: 3px;
+  min-width: 96px;
+}
+
+.step-segment {
+  border-radius: 2px;
+  display: block;
+  height: 10px;
+  min-width: 18px;
+}
+
+.empty-state {
+  background: #ffffff;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  margin: 0;
+  padding: 24px;
+}

--- a/ralph-v2/dashboard/style.css
+++ b/ralph-v2/dashboard/style.css
@@ -37,6 +37,40 @@ button {
   padding: 8px 14px;
 }
 
+.error-message,
+.warnings-banner {
+  border: 1px solid;
+  border-radius: 6px;
+  margin-bottom: 16px;
+  padding: 14px 16px;
+}
+
+.error-message {
+  background: #ffebe9;
+  border-color: #ff8182;
+  color: #82071e;
+}
+
+.warnings-banner {
+  background: #fff8c5;
+  border-color: #eac54f;
+  color: #7d4e00;
+}
+
+.warnings-banner h2 {
+  font-size: 15px;
+  margin: 0 0 8px;
+}
+
+.warnings-banner ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.warnings-banner li + li {
+  margin-top: 4px;
+}
+
 table {
   background: #ffffff;
   border: 1px solid #d0d7de;
@@ -56,6 +90,34 @@ th {
   background: #f6f8fa;
   font-size: 13px;
   font-weight: 650;
+}
+
+.pipeline-row {
+  cursor: pointer;
+}
+
+.pipeline-row:hover,
+.pipeline-row:focus {
+  background: #f6f8fa;
+  outline: none;
+}
+
+.pipeline-details-row td {
+  background: #fbfcfd;
+  padding: 0;
+}
+
+.step-details {
+  padding: 12px;
+}
+
+.step-details table {
+  border: 1px solid #d0d7de;
+}
+
+.empty-details {
+  margin: 0;
+  padding: 12px;
 }
 
 .status {

--- a/ralph-v2/dashboard/tests/test_dashboard_aggregate.sh
+++ b/ralph-v2/dashboard/tests/test_dashboard_aggregate.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DASHBOARD="$ROOT_DIR/dashboard/dashboard.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_jq_equals() {
+  local json="$1"
+  local filter="$2"
+  local expected="$3"
+  local actual
+
+  actual="$(jq -r "$filter" <<<"$json")"
+  [[ "$actual" == "$expected" ]] || fail "expected $filter to be $expected; got $actual"
+}
+
+assert_jq_true() {
+  local json="$1"
+  local filter="$2"
+
+  jq -e "$filter" <<<"$json" >/dev/null || fail "expected jq filter to pass: $filter"$'\n'"actual: $json"
+}
+
+run_aggregate() {
+  local workspaces_dir="$1"
+
+  "$DASHBOARD" aggregate --workspaces-dir "$workspaces_dir"
+}
+
+write_workspace_state() {
+  local workspaces_dir="$1"
+  local issue="$2"
+  local state_json="$3"
+
+  mkdir -p "$workspaces_dir/$issue"
+  printf '%s\n' "$state_json" > "$workspaces_dir/$issue/state.json"
+}
+
+test_zero_workspaces() {
+  local tmp_dir output
+
+  tmp_dir="$(mktemp -d)"
+  output="$(run_aggregate "$tmp_dir")"
+
+  assert_jq_equals "$output" '.workspaces | length' "0"
+  assert_jq_equals "$output" '.warnings | length' "0"
+
+  rm -rf "$tmp_dir"
+}
+
+test_completed_workspace() {
+  local tmp_dir output
+
+  tmp_dir="$(mktemp -d)"
+  write_workspace_state "$tmp_dir" 7 '{
+    "issue": 7,
+    "repo": "deepansh96/ralph",
+    "branch": "feat/completed",
+    "createdAt": "2026-05-02T12:00:00Z",
+    "steps": [
+      {
+        "id": "first-step",
+        "type": "review-decisions",
+        "agent": "claude",
+        "status": "completed",
+        "metrics": {
+          "duration_ms": 1000,
+          "cost_usd": 0.25
+        }
+      },
+      {
+        "id": "second-step",
+        "type": "create-prd",
+        "agent": "codex",
+        "status": "completed",
+        "metrics": {
+          "duration_ms": 2500,
+          "cost_usd": 0.75
+        }
+      }
+    ]
+  }'
+
+  output="$(run_aggregate "$tmp_dir")"
+
+  assert_jq_equals "$output" '.warnings | length' "0"
+  assert_jq_equals "$output" '.workspaces | length' "1"
+  assert_jq_equals "$output" '.workspaces[0].issue' "7"
+  assert_jq_equals "$output" '.workspaces[0].repo' "deepansh96/ralph"
+  assert_jq_equals "$output" '.workspaces[0].branch' "feat/completed"
+  assert_jq_equals "$output" '.workspaces[0].createdAt' "2026-05-02T12:00:00Z"
+  assert_jq_equals "$output" '.workspaces[0].derivedStatus' "completed"
+  assert_jq_equals "$output" '.workspaces[0].currentStep' "second-step"
+  assert_jq_equals "$output" '.workspaces[0].totalDuration_ms' "3500"
+  assert_jq_equals "$output" '.workspaces[0].totalCost_usd' "1"
+  assert_jq_equals "$output" '.workspaces[0].stepCounts.completed' "2"
+  assert_jq_equals "$output" '.workspaces[0].stepCounts.pending' "0"
+  assert_jq_equals "$output" '.workspaces[0].steps[0].id' "first-step"
+  assert_jq_equals "$output" '.workspaces[0].steps[0].duration_ms' "1000"
+  assert_jq_equals "$output" '.workspaces[0].steps[0].cost_usd' "0.25"
+
+  rm -rf "$tmp_dir"
+}
+
+test_mixed_workspaces_are_sorted_and_prioritized() {
+  local tmp_dir output
+
+  tmp_dir="$(mktemp -d)"
+  write_workspace_state "$tmp_dir" 30 '{
+    "issue": 30,
+    "repo": "deepansh96/ralph",
+    "branch": "feat/thirty",
+    "createdAt": "2026-05-02T12:30:00Z",
+    "steps": [
+      {"id": "done", "type": "fixed", "agent": "claude", "status": "completed", "metrics": {"duration_ms": 10, "cost_usd": 0.1}},
+      {"id": "active", "type": "dynamic", "agent": "codex", "status": "in_progress", "metrics": {"duration_ms": 20, "cost_usd": 0.2}}
+    ]
+  }'
+  write_workspace_state "$tmp_dir" 10 '{
+    "issue": 10,
+    "repo": "deepansh96/ralph",
+    "branch": "feat/ten",
+    "createdAt": "2026-05-02T12:10:00Z",
+    "steps": [
+      {"id": "done", "type": "fixed", "agent": "claude", "status": "completed", "metrics": {"duration_ms": 10, "cost_usd": 0.1}},
+      {"id": "next", "type": "dynamic", "agent": "codex", "status": "pending", "metrics": {"duration_ms": null, "cost_usd": null}}
+    ]
+  }'
+  write_workspace_state "$tmp_dir" 20 '{
+    "issue": 20,
+    "repo": "deepansh96/ralph",
+    "branch": "feat/twenty",
+    "createdAt": "2026-05-02T12:20:00Z",
+    "steps": [
+      {"id": "bad", "type": "fixed", "agent": "claude", "status": "failed", "metrics": {"duration_ms": 1, "cost_usd": 0.01}},
+      {"id": "blocked-later", "type": "dynamic", "agent": "codex", "status": "blocked", "metrics": {"duration_ms": 2, "cost_usd": 0.02}}
+    ]
+  }'
+
+  output="$(run_aggregate "$tmp_dir")"
+
+  assert_jq_equals "$output" '.workspaces | map(.issue) | join(",")' "10,20,30"
+  assert_jq_equals "$output" '.workspaces[0].derivedStatus' "pending"
+  assert_jq_equals "$output" '.workspaces[0].currentStep' "next"
+  assert_jq_equals "$output" '.workspaces[1].derivedStatus' "failed"
+  assert_jq_equals "$output" '.workspaces[1].currentStep' "bad"
+  assert_jq_equals "$output" '.workspaces[2].derivedStatus' "in_progress"
+  assert_jq_equals "$output" '.workspaces[2].currentStep' "active"
+
+  rm -rf "$tmp_dir"
+}
+
+test_invalid_files_are_skipped_with_warnings() {
+  local tmp_dir output
+
+  tmp_dir="$(mktemp -d)"
+  write_workspace_state "$tmp_dir" 1 '{
+    "issue": 1,
+    "repo": "deepansh96/ralph",
+    "branch": "feat/valid",
+    "createdAt": "2026-05-02T12:00:00Z",
+    "steps": [
+      {"id": "only", "type": "fixed", "agent": "codex", "status": "pending", "metrics": null}
+    ]
+  }'
+  mkdir -p "$tmp_dir/broken" "$tmp_dir/no-steps" "$tmp_dir/bad-issue"
+  printf '{not-json' > "$tmp_dir/broken/state.json"
+  printf '{"issue":2}' > "$tmp_dir/no-steps/state.json"
+  printf '{"issue":"3","steps":[]}' > "$tmp_dir/bad-issue/state.json"
+
+  output="$(run_aggregate "$tmp_dir")"
+
+  assert_jq_equals "$output" '.workspaces | length' "1"
+  assert_jq_equals "$output" '.workspaces[0].issue' "1"
+  assert_jq_equals "$output" '.warnings | length' "3"
+  assert_jq_true "$output" '.warnings[] | select(contains("broken/state.json: invalid JSON"))'
+  assert_jq_true "$output" '.warnings[] | select(contains("no-steps/state.json: .steps must be an array"))'
+  assert_jq_true "$output" '.warnings[] | select(contains("bad-issue/state.json: .issue must be numeric"))'
+
+  rm -rf "$tmp_dir"
+}
+
+test_invalid_step_status_is_skipped_with_warning() {
+  local tmp_dir output
+
+  tmp_dir="$(mktemp -d)"
+  write_workspace_state "$tmp_dir" 3 '{
+    "issue": 3,
+    "repo": "deepansh96/ralph",
+    "branch": "feat/bad-status",
+    "createdAt": "2026-05-02T12:00:00Z",
+    "steps": [
+      {"id": "mystery", "type": "fixed", "agent": "codex", "status": "waiting", "metrics": null}
+    ]
+  }'
+
+  output="$(run_aggregate "$tmp_dir")"
+
+  assert_jq_equals "$output" '.workspaces | length' "0"
+  assert_jq_equals "$output" '.warnings | length' "1"
+  assert_jq_true "$output" '.warnings[] | select(contains("step status must be one of pending, in_progress, completed, blocked, failed"))'
+
+  rm -rf "$tmp_dir"
+}
+
+test_missing_metrics_produce_zero_duration_and_null_cost() {
+  local tmp_dir output
+
+  tmp_dir="$(mktemp -d)"
+  write_workspace_state "$tmp_dir" 44 '{
+    "issue": 44,
+    "repo": "deepansh96/ralph",
+    "branch": "feat/missing-metrics",
+    "createdAt": "2026-05-02T12:00:00Z",
+    "steps": [
+      {"id": "without-metrics", "type": "fixed", "agent": "claude", "status": "pending"},
+      {"id": "null-metrics", "type": "dynamic", "agent": "codex", "status": "pending", "metrics": null}
+    ]
+  }'
+
+  output="$(run_aggregate "$tmp_dir")"
+
+  assert_jq_equals "$output" '.workspaces[0].totalDuration_ms' "0"
+  assert_jq_equals "$output" '.workspaces[0].totalCost_usd == null' "true"
+  assert_jq_equals "$output" '.workspaces[0].steps[0].duration_ms' "0"
+  assert_jq_equals "$output" '.workspaces[0].steps[0].cost_usd == null' "true"
+
+  rm -rf "$tmp_dir"
+}
+
+test_blocked_step_is_current_when_no_failed_step_exists() {
+  local tmp_dir output
+
+  tmp_dir="$(mktemp -d)"
+  write_workspace_state "$tmp_dir" 45 '{
+    "issue": 45,
+    "repo": "deepansh96/ralph",
+    "branch": "feat/blocked",
+    "createdAt": "2026-05-02T12:00:00Z",
+    "steps": [
+      {"id": "done", "type": "fixed", "agent": "claude", "status": "completed", "metrics": null},
+      {"id": "needs-input", "type": "dynamic", "agent": "codex", "status": "blocked", "metrics": null},
+      {"id": "active-later", "type": "dynamic", "agent": "codex", "status": "in_progress", "metrics": null}
+    ]
+  }'
+
+  output="$(run_aggregate "$tmp_dir")"
+
+  assert_jq_equals "$output" '.workspaces[0].derivedStatus' "blocked"
+  assert_jq_equals "$output" '.workspaces[0].currentStep' "needs-input"
+  assert_jq_equals "$output" '.workspaces[0].stepCounts.blocked' "1"
+  assert_jq_equals "$output" '.workspaces[0].stepCounts.in_progress' "1"
+
+  rm -rf "$tmp_dir"
+}
+
+test_environment_workspaces_dir_is_used_without_flag() {
+  local env_dir output
+
+  env_dir="$(mktemp -d)"
+  write_workspace_state "$env_dir" 49 '{
+    "issue": 49,
+    "repo": "deepansh96/ralph",
+    "branch": "feat/env-only",
+    "createdAt": "2026-05-02T12:00:00Z",
+    "steps": [
+      {"id": "env-step", "type": "fixed", "agent": "claude", "status": "pending", "metrics": null}
+    ]
+  }'
+
+  output="$(RALPH_WORKSPACES_DIR="$env_dir" "$DASHBOARD" aggregate)"
+
+  assert_jq_equals "$output" '.workspaces | length' "1"
+  assert_jq_equals "$output" '.workspaces[0].issue' "49"
+
+  rm -rf "$env_dir"
+}
+
+test_workspaces_dir_flag_precedes_environment() {
+  local env_dir flag_dir output
+
+  env_dir="$(mktemp -d)"
+  flag_dir="$(mktemp -d)"
+  write_workspace_state "$env_dir" 50 '{
+    "issue": 50,
+    "repo": "deepansh96/ralph",
+    "branch": "feat/env",
+    "createdAt": "2026-05-02T12:00:00Z",
+    "steps": [
+      {"id": "env-step", "type": "fixed", "agent": "claude", "status": "pending", "metrics": null}
+    ]
+  }'
+  write_workspace_state "$flag_dir" 51 '{
+    "issue": 51,
+    "repo": "deepansh96/ralph",
+    "branch": "feat/flag",
+    "createdAt": "2026-05-02T12:00:00Z",
+    "steps": [
+      {"id": "flag-step", "type": "fixed", "agent": "codex", "status": "pending", "metrics": null}
+    ]
+  }'
+
+  output="$(RALPH_WORKSPACES_DIR="$env_dir" "$DASHBOARD" aggregate --workspaces-dir "$flag_dir")"
+
+  assert_jq_equals "$output" '.workspaces | length' "1"
+  assert_jq_equals "$output" '.workspaces[0].issue' "51"
+
+  rm -rf "$env_dir" "$flag_dir"
+}
+
+test_zero_workspaces
+test_completed_workspace
+test_mixed_workspaces_are_sorted_and_prioritized
+test_invalid_files_are_skipped_with_warnings
+test_invalid_step_status_is_skipped_with_warning
+test_missing_metrics_produce_zero_duration_and_null_cost
+test_blocked_step_is_current_when_no_failed_step_exists
+test_environment_workspaces_dir_is_used_without_flag
+test_workspaces_dir_flag_precedes_environment
+
+echo "dashboard aggregate tests passed"

--- a/ralph-v2/dashboard/tests/test_dashboard_aggregate.sh
+++ b/ralph-v2/dashboard/tests/test_dashboard_aggregate.sh
@@ -313,6 +313,28 @@ test_workspaces_dir_flag_precedes_environment() {
   rm -rf "$env_dir" "$flag_dir"
 }
 
+test_empty_steps_derives_pending_not_completed() {
+  local tmp_dir output
+
+  tmp_dir="$(mktemp -d)"
+  write_workspace_state "$tmp_dir" 99 '{
+    "issue": 99,
+    "repo": "deepansh96/ralph",
+    "branch": "feat/empty-steps",
+    "createdAt": "2026-05-02T12:00:00Z",
+    "steps": []
+  }'
+
+  output="$(run_aggregate "$tmp_dir")"
+
+  assert_jq_equals "$output" '.workspaces | length' "1"
+  assert_jq_equals "$output" '.workspaces[0].derivedStatus' "pending"
+  assert_jq_equals "$output" '.workspaces[0].currentStep' "null"
+  assert_jq_equals "$output" '.workspaces[0].totalDuration_ms' "0"
+
+  rm -rf "$tmp_dir"
+}
+
 test_zero_workspaces
 test_completed_workspace
 test_mixed_workspaces_are_sorted_and_prioritized
@@ -320,6 +342,7 @@ test_invalid_files_are_skipped_with_warnings
 test_invalid_step_status_is_skipped_with_warning
 test_missing_metrics_produce_zero_duration_and_null_cost
 test_blocked_step_is_current_when_no_failed_step_exists
+test_empty_steps_derives_pending_not_completed
 test_environment_workspaces_dir_is_used_without_flag
 test_workspaces_dir_flag_precedes_environment
 

--- a/ralph-v2/dashboard/tests/test_dashboard_serve.sh
+++ b/ralph-v2/dashboard/tests/test_dashboard_serve.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DASHBOARD="$ROOT_DIR/dashboard/dashboard.sh"
+SERVER_PID=""
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "$SERVER_PID" ]]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+    SERVER_PID=""
+  fi
+}
+
+trap cleanup EXIT
+
+assert_jq_equals() {
+  local json="$1"
+  local filter="$2"
+  local expected="$3"
+  local actual
+
+  actual="$(jq -r "$filter" <<<"$json")"
+  [[ "$actual" == "$expected" ]] || fail "expected $filter to be $expected; got $actual"
+}
+
+write_workspace_state() {
+  local workspaces_dir="$1"
+  local issue="$2"
+
+  mkdir -p "$workspaces_dir/$issue"
+  jq -n \
+    --argjson issue "$issue" \
+    '{
+      issue: $issue,
+      repo: "deepansh96/ralph",
+      branch: "feat/dashboard",
+      createdAt: "2026-05-02T12:00:00Z",
+      steps: [
+        {
+          id: "serve-step",
+          type: "implement-slice",
+          agent: "codex",
+          status: "in_progress",
+          metrics: {
+            duration_ms: 83000,
+            cost_usd: 0.21
+          }
+        }
+      ]
+    }' > "$workspaces_dir/$issue/state.json"
+}
+
+start_server() {
+  local port="$1"
+  local workspaces_dir="$2"
+  local log_file="$3"
+
+  "$DASHBOARD" serve --port "$port" --workspaces-dir "$workspaces_dir" > "$log_file" 2>&1 &
+  SERVER_PID="$!"
+
+  for _ in {1..50}; do
+    if curl -fsS "http://127.0.0.1:$port/" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  fail "server did not start; log: $(cat "$log_file" 2>/dev/null || true)"
+}
+
+test_api_serves_configured_workspace_data() {
+  local tmp_dir port log_file response
+
+  tmp_dir="$(mktemp -d)"
+  port="19081"
+  log_file="$tmp_dir/server.log"
+  write_workspace_state "$tmp_dir/workspaces" 19
+
+  start_server "$port" "$tmp_dir/workspaces" "$log_file"
+  response="$(curl -fsS "http://127.0.0.1:$port/api/workspaces")"
+
+  assert_jq_equals "$response" '.workspaces | length' "1"
+  assert_jq_equals "$response" '.workspaces[0].issue' "19"
+  assert_jq_equals "$response" '.workspaces[0].currentStep' "serve-step"
+  grep -q "Dashboard: http://127.0.0.1:$port" "$log_file" || fail "startup URL was not printed"
+
+  cleanup
+  rm -rf "$tmp_dir"
+}
+
+test_static_file_server_rejects_path_traversal() {
+  local tmp_dir port log_file plain_status encoded_status
+
+  tmp_dir="$(mktemp -d)"
+  port="19082"
+  log_file="$tmp_dir/server.log"
+
+  start_server "$port" "$tmp_dir/workspaces" "$log_file"
+  plain_status="$(curl --path-as-is -o /dev/null -s -w "%{http_code}" "http://127.0.0.1:$port/../../etc/passwd")"
+  encoded_status="$(curl --path-as-is -o /dev/null -s -w "%{http_code}" "http://127.0.0.1:$port/%2e%2e%2f%2e%2e%2fetc/passwd")"
+
+  [[ "$plain_status" == "403" || "$plain_status" == "404" ]] || fail "expected traversal request to be rejected; got $plain_status"
+  [[ "$encoded_status" == "403" || "$encoded_status" == "404" ]] || fail "expected encoded traversal request to be rejected; got $encoded_status"
+
+  cleanup
+  rm -rf "$tmp_dir"
+}
+
+test_api_reports_aggregate_failure_as_json() {
+  local tmp_dir port log_file response_body status
+
+  tmp_dir="$(mktemp -d)"
+  port="19083"
+  log_file="$tmp_dir/server.log"
+  response_body="$tmp_dir/response.json"
+  printf 'not a directory\n' > "$tmp_dir/not-a-directory"
+
+  start_server "$port" "$tmp_dir/not-a-directory" "$log_file"
+  status="$(curl -o "$response_body" -s -w "%{http_code}" "http://127.0.0.1:$port/api/workspaces")"
+
+  [[ "$status" == "500" ]] || fail "expected aggregate failure to return HTTP 500; got $status with $(cat "$response_body")"
+  assert_jq_equals "$(cat "$response_body")" '.error' "aggregate failed"
+
+  cleanup
+  rm -rf "$tmp_dir"
+}
+
+test_server_validates_jq_at_startup() {
+  local tmp_dir fake_bin python_path output status
+
+  tmp_dir="$(mktemp -d)"
+  fake_bin="$tmp_dir/bin"
+  mkdir -p "$fake_bin"
+  python_path="$(command -v python3)"
+  ln -s "$python_path" "$fake_bin/python3"
+
+  set +e
+  output="$(PATH="$fake_bin" /bin/bash "$DASHBOARD" serve --port 19084 --workspaces-dir "$tmp_dir/workspaces" 2>&1)"
+  status="$?"
+  set -e
+
+  [[ "$status" != "0" ]] || fail "expected serve to fail when jq is missing"
+  [[ "$output" == *"jq is required"* ]] || fail "expected missing jq message; got $output"
+
+  rm -rf "$tmp_dir"
+}
+
+test_frontend_static_assets_expose_pipeline_table() {
+  local tmp_dir port log_file html css
+
+  tmp_dir="$(mktemp -d)"
+  port="19085"
+  log_file="$tmp_dir/server.log"
+
+  start_server "$port" "$tmp_dir/workspaces" "$log_file"
+  html="$(curl -fsS "http://127.0.0.1:$port/")"
+  css="$(curl -fsS "http://127.0.0.1:$port/style.css")"
+
+  [[ "$html" == *"Pipeline Dashboard"* ]] || fail "expected Pipeline Dashboard heading"
+  [[ "$html" == *"Refresh"* ]] || fail "expected refresh button"
+  [[ "$html" == *"Issue #"* ]] || fail "expected issue column"
+  [[ "$html" == *"Current Step"* ]] || fail "expected current Step column"
+  [[ "$html" == *"Steps Progress"* ]] || fail "expected Steps Progress column"
+  [[ "$html" == *"formatDuration"* ]] || fail "expected duration formatter"
+  [[ "$html" == *"formatCost"* ]] || fail "expected cost formatter"
+  [[ "$html" != *"Loop"* && "$html" != *"Iteration"* ]] || fail "frontend must not use Loop or Iteration labels"
+  [[ "$css" == *"status-completed"* && "$css" == *"status-in_progress"* && "$css" == *"status-blocked"* && "$css" == *"status-failed"* && "$css" == *"status-pending"* ]] || fail "expected status color classes"
+  [[ "$css" == *"step-segment"* ]] || fail "expected compact Step progress segment styles"
+
+  cleanup
+  rm -rf "$tmp_dir"
+}
+
+test_api_serves_configured_workspace_data
+test_static_file_server_rejects_path_traversal
+test_api_reports_aggregate_failure_as_json
+test_server_validates_jq_at_startup
+test_frontend_static_assets_expose_pipeline_table
+
+echo "dashboard serve tests passed"

--- a/ralph-v2/dashboard/tests/test_dashboard_serve.sh
+++ b/ralph-v2/dashboard/tests/test_dashboard_serve.sh
@@ -101,6 +101,7 @@ test_static_file_server_rejects_path_traversal() {
   tmp_dir="$(mktemp -d)"
   port="19082"
   log_file="$tmp_dir/server.log"
+  mkdir -p "$tmp_dir/workspaces"
 
   start_server "$port" "$tmp_dir/workspaces" "$log_file"
   plain_status="$(curl --path-as-is -o /dev/null -s -w "%{http_code}" "http://127.0.0.1:$port/../../etc/passwd")"
@@ -114,21 +115,40 @@ test_static_file_server_rejects_path_traversal() {
 }
 
 test_api_reports_aggregate_failure_as_json() {
-  local tmp_dir port log_file response_body status
+  local tmp_dir port log_file response_body status ws_dir
 
   tmp_dir="$(mktemp -d)"
   port="19083"
   log_file="$tmp_dir/server.log"
   response_body="$tmp_dir/response.json"
-  printf 'not a directory\n' > "$tmp_dir/not-a-directory"
+  ws_dir="$tmp_dir/workspaces"
+  mkdir -p "$ws_dir"
 
-  start_server "$port" "$tmp_dir/not-a-directory" "$log_file"
+  start_server "$port" "$ws_dir" "$log_file"
+  rm -rf "$ws_dir"
   status="$(curl -o "$response_body" -s -w "%{http_code}" "http://127.0.0.1:$port/api/workspaces")"
 
   [[ "$status" == "500" ]] || fail "expected aggregate failure to return HTTP 500; got $status with $(cat "$response_body")"
   assert_jq_equals "$(cat "$response_body")" '.error' "aggregate failed"
 
   cleanup
+  rm -rf "$tmp_dir"
+}
+
+test_serve_validates_workspaces_directory() {
+  local tmp_dir output status
+
+  tmp_dir="$(mktemp -d)"
+  printf 'not a directory\n' > "$tmp_dir/not-a-directory"
+
+  set +e
+  output="$("$DASHBOARD" serve --port 19083 --workspaces-dir "$tmp_dir/not-a-directory" 2>&1)"
+  status="$?"
+  set -e
+
+  [[ "$status" != "0" ]] || fail "expected serve to fail for non-directory path"
+  [[ "$output" == *"workspaces directory does not exist or is not a directory"* ]] || fail "expected directory validation error; got $output"
+
   rm -rf "$tmp_dir"
 }
 
@@ -162,6 +182,8 @@ test_server_validates_jq_at_startup() {
   python_path="$(command -v python3)"
   ln -s "$python_path" "$fake_bin/python3"
 
+  mkdir -p "$tmp_dir/workspaces"
+
   set +e
   output="$(PATH="$fake_bin" /bin/bash "$DASHBOARD" serve --port 19084 --workspaces-dir "$tmp_dir/workspaces" 2>&1)"
   status="$?"
@@ -179,6 +201,7 @@ test_frontend_static_assets_expose_pipeline_table() {
   tmp_dir="$(mktemp -d)"
   port="19085"
   log_file="$tmp_dir/server.log"
+  mkdir -p "$tmp_dir/workspaces"
 
   start_server "$port" "$tmp_dir/workspaces" "$log_file"
   html="$(curl -fsS "http://127.0.0.1:$port/")"
@@ -205,6 +228,7 @@ test_frontend_static_assets_expose_resilient_interactions() {
   tmp_dir="$(mktemp -d)"
   port="19086"
   log_file="$tmp_dir/server.log"
+  mkdir -p "$tmp_dir/workspaces"
 
   start_server "$port" "$tmp_dir/workspaces" "$log_file"
   html="$(curl -fsS "http://127.0.0.1:$port/")"
@@ -224,6 +248,7 @@ test_frontend_static_assets_expose_resilient_interactions() {
 test_api_serves_configured_workspace_data
 test_static_file_server_rejects_path_traversal
 test_api_reports_aggregate_failure_as_json
+test_serve_validates_workspaces_directory
 test_api_surfaces_warnings_for_malformed_workspace_files
 test_server_validates_jq_at_startup
 test_frontend_static_assets_expose_pipeline_table

--- a/ralph-v2/dashboard/tests/test_dashboard_serve.sh
+++ b/ralph-v2/dashboard/tests/test_dashboard_serve.sh
@@ -132,6 +132,27 @@ test_api_reports_aggregate_failure_as_json() {
   rm -rf "$tmp_dir"
 }
 
+test_api_surfaces_warnings_for_malformed_workspace_files() {
+  local tmp_dir port log_file response
+
+  tmp_dir="$(mktemp -d)"
+  port="19084"
+  log_file="$tmp_dir/server.log"
+  write_workspace_state "$tmp_dir/workspaces" 21
+  mkdir -p "$tmp_dir/workspaces/broken"
+  printf '{not-json' > "$tmp_dir/workspaces/broken/state.json"
+
+  start_server "$port" "$tmp_dir/workspaces" "$log_file"
+  response="$(curl -fsS "http://127.0.0.1:$port/api/workspaces")"
+
+  assert_jq_equals "$response" '.workspaces | length' "1"
+  assert_jq_equals "$response" '.warnings | length' "1"
+  [[ "$response" == *"broken/state.json: invalid JSON"* ]] || fail "expected malformed workspace warning"
+
+  cleanup
+  rm -rf "$tmp_dir"
+}
+
 test_server_validates_jq_at_startup() {
   local tmp_dir fake_bin python_path output status
 
@@ -178,10 +199,34 @@ test_frontend_static_assets_expose_pipeline_table() {
   rm -rf "$tmp_dir"
 }
 
+test_frontend_static_assets_expose_resilient_interactions() {
+  local tmp_dir port log_file html
+
+  tmp_dir="$(mktemp -d)"
+  port="19086"
+  log_file="$tmp_dir/server.log"
+
+  start_server "$port" "$tmp_dir/workspaces" "$log_file"
+  html="$(curl -fsS "http://127.0.0.1:$port/")"
+
+  [[ "$html" == *"id=\"warnings-banner\""* ]] || fail "expected warnings banner container"
+  [[ "$html" == *"id=\"dashboard-error\""* ]] || fail "expected inline error container"
+  [[ "$html" == *"data-pipeline-row"* ]] || fail "expected expandable Pipeline rows"
+  [[ "$html" == *"togglePipelineDetails"* ]] || fail "expected row expansion handler"
+  [[ "$html" == *"renderStepDetails"* ]] || fail "expected Step detail renderer"
+  [[ "$html" == *"response.status"* ]] || fail "expected non-2xx HTTP status handling"
+  [[ "$html" == *"warnings.forEach"* ]] || fail "expected warning list rendering"
+
+  cleanup
+  rm -rf "$tmp_dir"
+}
+
 test_api_serves_configured_workspace_data
 test_static_file_server_rejects_path_traversal
 test_api_reports_aggregate_failure_as_json
+test_api_surfaces_warnings_for_malformed_workspace_files
 test_server_validates_jq_at_startup
 test_frontend_static_assets_expose_pipeline_table
+test_frontend_static_assets_expose_resilient_interactions
 
 echo "dashboard serve tests passed"


### PR DESCRIPTION
## Summary

Adds a minimal local web dashboard for monitoring active Ralph pipelines at a glance. The dashboard is a self-contained tool in `ralph-v2/dashboard/` with no external dependencies beyond `bash`, `python3`, and `jq`.

- **`dashboard.sh aggregate`** — CLI subcommand that reads `state.json` from all active workspaces, validates schema, derives pipeline status and current step using priority rules, computes duration/cost totals, and outputs structured JSON on stdout
- **`dashboard.sh serve`** — Starts a localhost-only HTTP server (embedded Python `BaseHTTPRequestHandler`) that wraps the aggregate CLI as a JSON API at `GET /api/workspaces` and serves the static frontend
- **Frontend** (`index.html` + `style.css`) — Single-page table with color-coded pipeline statuses, compact step progress segments, expandable row details, warnings banner for malformed workspace files, manual refresh, and inline error display
- **Tests** — 9 aggregate tests and 7 serve tests covering validation, derivation rules, edge cases, path traversal protection, and error responses

### Key design decisions

- Server binds to `127.0.0.1` only — no network exposure
- Path traversal protection with layered string checks and resolved-path containment
- XSS prevention via HTML escaping in all dynamic content
- Pipeline status derived from step states (not stale top-level field) using priority: failed > blocked > in_progress > completed > pending
- Uses CONTEXT.md vocabulary throughout: "Pipeline" and "Step" (never "Loop" or "Iteration")
- No npm, no build step, no CDN — fully offline-capable

## Linked Issues

- Closes #18 — Aggregate active workspaces as CLI JSON
- Closes #19 — Localhost dashboard serving pipeline overview table
- Closes #20 — Row expansion, warnings banner, and error resilience
- Parent: #17

## Final Review

**Outcome: Pass.** All three sub-issues' acceptance criteria are fully satisfied. Both test suites pass (9 aggregate tests, 7 serve tests). No regressions, missing pieces, or blockers found.

Key findings from the final review:
- Security: Path traversal protection is layered (string check + resolved-path containment). XSS prevention via `escapeHtml`. Server binds to localhost only. No command injection vectors.
- Code quality: Clean separation between data layer (`aggregate`) and presentation (`serve` + frontend). The aggregate subcommand doubles as an independently useful CLI tool.
- Edge cases: Zero workspaces, null metrics, malformed files, and all status combinations are handled and tested.
- No scope creep: Implementation stays within `ralph-v2/dashboard/` with no coupling to orchestrator code.

## Human QA Checklist

- [ ] Run `bash ralph-v2/dashboard/tests/test_dashboard_aggregate.sh` — all 9 tests pass
- [ ] Run `bash ralph-v2/dashboard/tests/test_dashboard_serve.sh` — all 7 tests pass
- [ ] Start server: `./ralph-v2/dashboard/dashboard.sh serve` — prints `Dashboard: http://127.0.0.1:8080`
- [ ] Open `http://127.0.0.1:8080` — table renders with active workspaces
- [ ] Verify status color coding: green (completed), blue (in_progress), amber (blocked), red (failed), grey (pending)
- [ ] Click a pipeline row — detail panel expands showing per-step breakdown
- [ ] Click expanded row — detail panel collapses
- [ ] Click refresh button — table updates with fresh data
- [ ] Test with zero workspaces — empty state message displays
- [ ] Add malformed `state.json` to a workspace — warnings banner appears above table
- [ ] Stop server and click refresh — inline error message displays
- [ ] Restart server and click refresh — error clears, table recovers
- [ ] Test `--port` flag: `./ralph-v2/dashboard/dashboard.sh serve --port 9090`
- [ ] Test `--workspaces-dir` flag with custom path
- [ ] Verify no requests to external CDNs (fully offline)
- [ ] Verify all UI labels say "Pipeline" and "Step" (never "Loop" or "Iteration")
